### PR TITLE
Full site redesign + accumulated dev work

### DIFF
--- a/src/components/products/InventoryCard.tsx
+++ b/src/components/products/InventoryCard.tsx
@@ -6,10 +6,9 @@ import { ResponseInventoriesInfo } from '../../types/inventory';
 
 interface InventoryCardProps {
     inventory: ResponseInventoriesInfo;
-    index?: number;
 }
 
-const InventoryCard: React.FC<InventoryCardProps> = React.memo(({ inventory, index = 0 }) => {
+const InventoryCard: React.FC<InventoryCardProps> = React.memo(({ inventory }) => {
     const { id, title, imagePath, lists } = inventory;
     const navigate = useNavigate();
 
@@ -24,11 +23,8 @@ const InventoryCard: React.FC<InventoryCardProps> = React.memo(({ inventory, ind
                 }}
             />
 
-            <div className="absolute top-4 left-4 right-4 flex items-center justify-between text-white/85">
-                <span className="font-mono text-[10.5px] tracking-[0.25em]">
-                    INVENTARIO · {String(index + 1).padStart(2, '0')}
-                </span>
-                <span className="size-1.5 rounded-full bg-accent" />
+            <div className="absolute top-4 right-4">
+                <span className="size-1.5 rounded-full bg-accent block" />
             </div>
 
             <div className="absolute inset-x-4 bottom-4 flex flex-col text-white">

--- a/src/components/products/InventoryList.tsx
+++ b/src/components/products/InventoryList.tsx
@@ -17,8 +17,8 @@ const InventoryList: React.FC<InventoryListProps> = React.memo(({ inventories, c
 
   return (
     <div className={classname}>
-      {inventories.map((inventory, idx) => (
-        <InventoryCard key={inventory.id} inventory={inventory} index={idx} />
+      {inventories.map((inventory) => (
+        <InventoryCard key={inventory.id} inventory={inventory} />
       ))}
     </div>
   )

--- a/src/pages/project/Inventories.tsx
+++ b/src/pages/project/Inventories.tsx
@@ -10,8 +10,6 @@ import { CONTACT_INFO } from '../../constants/social_networks';
 const Inventories: React.FC = () => {
     const { data: inventories, isLoading, isError, error } = useGetAllInventoriesInfo();
 
-    const totalLists = (inventories || []).reduce((acc, inv) => acc + (inv.lists?.length || 0), 0);
-
     return (
         <>
             {/* Hero */}
@@ -23,31 +21,9 @@ const Inventories: React.FC = () => {
                         <span>›</span>
                         <span className="text-white">CATÁLOGO</span>
                     </nav>
-                    <div className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] tracking-[0.2em] text-white/85 mb-6 bg-white/10 border border-white/15">
-                        <span className="size-1.5 rounded-full bg-accent" /> CATÁLOGO COMPLETO
-                    </div>
                     <h1 className="font-display font-black text-[40px] lg:text-[60px] leading-[1.02] tracking-tight max-w-[820px]">
                         Catálogo de artículos publicitarios.
                     </h1>
-                    <p className="mt-4 text-white/70 text-[15px] lg:text-[16px] max-w-[620px] leading-relaxed">
-                        Explora nuestros inventarios y sublistas. Personalizamos cada producto con tu marca, colores y arte.
-                    </p>
-                    <div className="mt-8 flex flex-wrap items-center gap-8 text-white/80">
-                        <div>
-                            <div className="font-display font-black text-3xl text-accent">{inventories?.length ?? '—'}</div>
-                            <div className="font-mono text-[10px] tracking-[0.25em] text-white/55 mt-1">INVENTARIOS</div>
-                        </div>
-                        <div className="h-10 w-px bg-white/15" />
-                        <div>
-                            <div className="font-display font-black text-3xl text-accent">{totalLists || '—'}</div>
-                            <div className="font-mono text-[10px] tracking-[0.25em] text-white/55 mt-1">SUBCATEGORÍAS</div>
-                        </div>
-                        <div className="h-10 w-px bg-white/15" />
-                        <div>
-                            <div className="font-display font-black text-3xl text-accent">+20</div>
-                            <div className="font-mono text-[10px] tracking-[0.25em] text-white/55 mt-1">AÑOS</div>
-                        </div>
-                    </div>
                 </div>
             </section>
 

--- a/src/pages/project/ProductView.tsx
+++ b/src/pages/project/ProductView.tsx
@@ -44,7 +44,7 @@ const ProductView: React.FC = () => {
         <main className="bg-yp-paper">
             {/* Breadcrumb */}
             <div className="bg-white border-b border-yp-line">
-                <div className="max-w-[1400px] mx-auto px-6 py-3.5 flex items-center gap-2 text-[11px] font-mono tracking-[0.18em] text-yp-muted">
+                <div className="max-w-[1400px] mx-auto px-6 py-3.5 flex items-center gap-2 text-[11px] tracking-[0.18em] text-yp-muted">
                     <Link to="/" className="hover:text-yp-bright transition">INICIO</Link>
                     <Icon name="chevronRight" className="h-3 w-3" />
                     <Link to="/inventarios" className="hover:text-yp-bright transition">PRODUCTOS</Link>
@@ -65,12 +65,12 @@ const ProductView: React.FC = () => {
                                     className="absolute inset-0 w-full h-full object-contain p-8"
                                 />
                             ) : (
-                                <div className="absolute inset-0 grid place-items-center font-mono text-[12px] tracking-[0.25em] text-yp-deep/40">
+                                <div className="absolute inset-0 grid place-items-center text-[12px] tracking-[0.25em] text-yp-deep/40">
                                     SIN IMAGEN
                                 </div>
                             )}
                             <div className="absolute top-4 left-4 flex flex-col gap-2">
-                                <span className="bg-accent text-yp-deep font-mono text-[10px] tracking-[0.18em] px-2.5 py-1 rounded-full font-bold">
+                                <span className="bg-accent text-yp-deep text-[10px] tracking-[0.18em] px-2.5 py-1 rounded-full font-bold">
                                     ENTREGA 24H
                                 </span>
                             </div>
@@ -95,7 +95,7 @@ const ProductView: React.FC = () => {
 
                     {/* Info */}
                     <div className="lg:col-span-6">
-                        <div className="flex items-center gap-3 text-[11px] font-mono tracking-[0.2em] text-yp-bright">
+                        <div className="flex items-center gap-3 text-[11px] tracking-[0.2em] text-yp-bright">
                             <span className="size-1.5 rounded-full bg-yp-bright" /> PRODUCTO
                             <span className="text-yp-line">·</span>
                             <span className="text-yp-muted">SKU {productId.slice(0, 8).toUpperCase()}</span>
@@ -132,7 +132,7 @@ const ProductView: React.FC = () => {
                         {/* Price */}
                         {product.price && (
                             <div className="mt-7">
-                                <div className="font-mono text-[10px] tracking-[0.25em] text-yp-muted mb-1">PRECIO UNITARIO</div>
+                                <div className="text-[10px] tracking-[0.25em] text-yp-muted mb-1">PRECIO UNITARIO</div>
                                 <div className="font-display font-black text-[30px] lg:text-[34px] leading-none text-yp-deep tracking-tight">
                                     {product.price}
                                 </div>
@@ -144,13 +144,13 @@ const ProductView: React.FC = () => {
                         {colors.length > 0 && (
                             <div className="mt-7">
                                 <div className="flex items-center justify-between mb-3">
-                                    <div className="font-mono text-[10px] tracking-[0.25em] text-yp-muted">
+                                    <div className="text-[10px] tracking-[0.25em] text-yp-muted">
                                         COLOR ·{' '}
                                         <span className="text-yp-deep font-semibold normal-case tracking-normal">
                                             {selectedColor?.name || 'selecciona'}
                                         </span>
                                     </div>
-                                    <div className="font-mono text-[10px] tracking-[0.2em] text-yp-muted">
+                                    <div className="text-[10px] tracking-[0.2em] text-yp-muted">
                                         {colors.length} OPCIONES
                                     </div>
                                 </div>
@@ -278,7 +278,7 @@ const SpecRow: React.FC<{ label: string; value?: string | null; last?: boolean }
     if (!value) return null;
     return (
         <div className={`grid grid-cols-12 gap-4 py-3 ${last ? '' : 'border-b border-yp-line'}`}>
-            <div className="col-span-5 lg:col-span-4 font-mono text-[10.5px] tracking-[0.2em] text-yp-muted uppercase pt-0.5">
+            <div className="col-span-5 lg:col-span-4 text-[10.5px] tracking-[0.2em] text-yp-muted uppercase pt-0.5">
                 {label}
             </div>
             <div className="col-span-7 lg:col-span-8 text-[14px] text-yp-deep">{value}</div>


### PR DESCRIPTION
## Summary

Promotes `design-changes` directly to `main`. This branch contains the full visual rework against the Claude Design handoff **plus** everything currently sitting on `dev` that has not yet reached `main` (~220 commits total).

### Redesign work (this branch)
- **Phase 1** — Design tokens (`yp-deep/mid/bright/paper/line/muted/ink`, `accent`), typography (Archivo Display + Manrope + JetBrains Mono), utilities (`yp-gradient`, `yp-gradient-radial`, `grid-bg`, `card-shadow`, `hover-lift`, `pill`, `marquee-mask`, `ticker`) + Playwright smoke setup.
- **Phase 2** — Header (top-strip + sticky yp-gradient bar + accent COTIZAR) and dark Footer (4 columns, real contact info, no newsletter / LinkedIn).
- **Phase 3** — Home: Hero (rotating slides + animated trust marquee), Services, Process, Featured carousel reskin.
- **Phase 4** — Catalog (`Inventories`) banner cards and Inventory page with sticky sidebar + price + color filters + chips/empty states.
- **Phase 5** — Product detail: gallery card, specs in label rows, swatches, qty −/+, navy AÑADIR A COTIZACIÓN + accent WhatsApp, tabs.
- **Phase 6** — Quiénes Somos, Contáctanos (form with success + dark hours card + map + social), cleanup of orphaned components.

### Modal redesigns
- **LoginModal** — split-panel 920px with floating labels, live password strength meter.
- **RegisterModal** — split-panel 1020px with segmented Regular/Publicista selector, drag-and-drop RUT field.
- **UserModal** — 320px dropdown anchored under the profile button via `#user-menu-anchor` + `getBoundingClientRect`.

### Polish included
- Global `BackButton` removed (breadcrumbs cover navigation).
- Trust-marquee animation fixed and `spark` SVG rewritten as a real 4-point sparkle.
- COTIZAR in Header routes to `/inventarios` (in-app quotation flow) instead of WhatsApp.
- Catalog hero simplified (no badge / no subtitle / no stats).
- `INVENTARIO · 0X` tag removed from banner cards.
- ProductView labels switched from JetBrains Mono to Manrope.

## Known follow-ups (not in this PR)
- Variants table and "productos similares" in ProductView need backend (per-color stock/SKU + related endpoint).
- "Todos los productos" grouped mode in Inventory needs an endpoint returning all products of an inventory at once.
- UserModal does not show email / role / ID — `AuthContext` has no `/me` payload yet.
- Pre-existing lint errors (36) in `useResendActivationEmail.ts` and `main.tsx` not touched.

## Test plan
- [ ] `npm run build` clean
- [ ] Home: Hero rotates, marquee animated, Services/Process/Featured render
- [ ] Header sticky with shadow on scroll; COTIZAR goes to /inventarios; mobile menu works
- [ ] Footer dark with real Cali contact info, no newsletter
- [ ] /inventarios shows banner cards (no INVENTARIO chip), bullets navigate with state.listId
- [ ] /inventario/:id sidebar filters (price + color) work, chips removable, empty state CTA fires
- [ ] /producto/:id breadcrumb + gallery + specs (in Manrope), swatches, qty, both CTAs
- [ ] /quienes-somos and /contactanos render redesigned layouts; form goes to success state
- [ ] Login modal: split-panel, strength meter live, can switch to Register
- [ ] Register modal: type selector, drag-and-drop RUT field, legal checks gate submit
- [ ] UserModal: opens as dropdown directly under the profile button; Cerrar sesión logs out

🤖 Generated with [Claude Code](https://claude.com/claude-code)