### PR TITLE
Legal pages redesign + Hero carousel wiring

### DIFF
--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Icon from '../icon/Icon';
 import { CONTACT_INFO } from '../../constants/social_networks';
+import { useCarouselImages } from '../../hooks/useCarouselImages';
 
 type Slide = { tag: string; title: string; sub: string; placeholder: string };
 
@@ -36,11 +37,15 @@ const TRUST_ITEMS = [
 
 const Hero: React.FC = () => {
     const [i, setI] = useState(0);
+    const { data: carousel } = useCarouselImages();
+    const images = carousel?.carouselImages ?? [];
+
     useEffect(() => {
         const t = setTimeout(() => setI((i + 1) % SLIDES.length), 5500);
         return () => clearTimeout(t);
     }, [i]);
     const s = SLIDES[i];
+    const imageUrl = images[i % Math.max(images.length, 1)];
 
     return (
         <section className="relative yp-gradient-radial text-white overflow-hidden">
@@ -112,9 +117,19 @@ const Hero: React.FC = () => {
 
                 <div className="lg:col-span-5 relative">
                     <div className="relative aspect-[5/6] rounded-3xl overflow-hidden ring-1 ring-white/10 bg-yp-paper">
-                        <div className="absolute inset-0 grid place-items-center font-mono text-[11px] tracking-[0.3em] text-yp-deep/55">
-                            {s.placeholder}
-                        </div>
+                        {imageUrl ? (
+                            <img
+                                key={imageUrl}
+                                src={imageUrl}
+                                alt={s.tag}
+                                className="absolute inset-0 w-full h-full object-cover"
+                                loading="eager"
+                            />
+                        ) : (
+                            <div className="absolute inset-0 grid place-items-center font-mono text-[11px] tracking-[0.3em] text-yp-deep/55">
+                                {s.placeholder}
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/hooks/useCarouselImages.ts
+++ b/src/hooks/useCarouselImages.ts
@@ -1,0 +1,13 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { QUERY_KEYS } from '../api/queryKeys';
+import { serviceCarousel } from '../services/serviceCarousel';
+import { GetCarouselImages } from '../types/GetCarouselImages';
+
+export const useCarouselImages = (): UseQueryResult<GetCarouselImages, Error> =>
+    useQuery<GetCarouselImages, Error, GetCarouselImages, readonly string[]>({
+        queryKey: QUERY_KEYS.carousel.images,
+        queryFn: () => serviceCarousel.fetchCarouselImages(),
+        staleTime: 1000 * 60 * 60 * 2,
+        gcTime: 1000 * 60 * 60 * 2,
+        refetchOnWindowFocus: false,
+    });

--- a/src/pages/legal/LegalAdvicePage.tsx
+++ b/src/pages/legal/LegalAdvicePage.tsx
@@ -1,92 +1,386 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+
+type Section = {
+    id: string;
+    n: string;
+    title: string;
+    content: React.ReactNode;
+};
+
+const SECTIONS: Section[] = [
+    {
+        id: 's1',
+        n: '01',
+        title: 'Identificación y titularidad',
+        content: (
+            <p>
+                A continuación el Titular expone sus datos identificativos para conocimiento de los usuarios del Sitio
+                Web. Los datos completos pueden consultarse en la tarjeta superior.
+            </p>
+        ),
+    },
+    {
+        id: 's2',
+        n: '02',
+        title: 'Finalidad',
+        content: (
+            <p>
+                La finalidad del Sitio Web es informar sobre los servicios de impresión, marcación, promocionales y
+                publicidad ofrecidos por Yanca Publicidad, así como facilitar la cotización y gestión de pedidos a
+                clientes finales y publicistas.
+            </p>
+        ),
+    },
+    {
+        id: 's3',
+        n: '03',
+        title: 'Condiciones de uso',
+        content: (
+            <>
+                <p>
+                    La utilización del Sitio Web le otorga la condición de Usuario, e implica la aceptación completa de
+                    todas las cláusulas y condiciones de uso incluidas en las páginas:
+                </p>
+                <ul className="list-disc pl-6 mt-3 space-y-1">
+                    <li>Aviso Legal</li>
+                    <li>Política de Privacidad</li>
+                </ul>
+                <p className="mt-3">
+                    Si no estuviera conforme con todas y cada una de estas cláusulas y condiciones absténgase de
+                    utilizar el Sitio Web. El acceso al Sitio Web no supone, en modo alguno, el inicio de una relación
+                    comercial con el Titular.
+                </p>
+            </>
+        ),
+    },
+    {
+        id: 's4',
+        n: '04',
+        title: 'Medidas de seguridad',
+        content: (
+            <>
+                <p>
+                    Los datos personales que facilite al Titular pueden ser almacenados en bases de datos automatizadas
+                    o no, cuya titularidad corresponde en exclusiva al Titular, que asume todas las medidas de índole
+                    técnica, organizativa y de seguridad que garantizan la confidencialidad, integridad y calidad de la
+                    información contenida en las mismas de acuerdo con lo establecido en la normativa vigente en
+                    protección de datos.
+                </p>
+                <p className="mt-3">
+                    No obstante, debe ser consciente que las medidas de seguridad de los sistemas informáticos en
+                    Internet no son enteramente fiables y que, por tanto el Titular no puede garantizar la inexistencia
+                    de virus u otros elementos que puedan producir alteraciones en los sistemas informáticos del
+                    Usuario.
+                </p>
+            </>
+        ),
+    },
+    {
+        id: 's5',
+        n: '05',
+        title: 'Tratamiento de datos personales',
+        content: (
+            <p>
+                Puede consultar toda la información relativa al tratamiento de datos personales que recoge el Titular
+                en la{' '}
+                <Link
+                    to="/politicas-privacidad"
+                    className="text-yp-bright border-b border-yp-bright/40 hover:border-yp-bright"
+                >
+                    Política de Privacidad
+                </Link>
+                .
+            </p>
+        ),
+    },
+    {
+        id: 's6',
+        n: '06',
+        title: 'Contenidos',
+        content: (
+            <>
+                <p>
+                    El Titular ha obtenido la información, el contenido multimedia y los materiales incluidos en el
+                    Sitio Web de fuentes que considera fiables, pero, si bien ha tomado todas las medidas razonables
+                    para asegurar que la información contenida es correcta, el Titular no garantiza que sea exacta,
+                    completa o actualizada.
+                </p>
+                <p className="mt-3">
+                    Queda prohibido transmitir o enviar a través del Sitio Web cualquier contenido ilegal o ilícito,
+                    virus informáticos, o mensajes que, en general, afecten o violen derechos del Titular o de terceros.
+                </p>
+            </>
+        ),
+    },
+    {
+        id: 's7',
+        n: '07',
+        title: 'Política de cookies',
+        content: (
+            <>
+                <p>El Titular obtiene y conserva la siguiente información acerca de los visitantes del Sitio Web:</p>
+                <ul className="list-disc pl-6 mt-3 space-y-1">
+                    <li>El nombre de dominio del proveedor (PSI) y/o dirección IP que les da acceso a la red.</li>
+                    <li>La fecha y hora de acceso al sitio Web.</li>
+                    <li>La dirección de Internet origen del enlace que dirige al sitio Web.</li>
+                    <li>El número de visitantes diarios de cada sección.</li>
+                </ul>
+                <p className="mt-3">
+                    La información obtenida es totalmente anónima, y en ningún caso puede ser asociada a un Usuario
+                    concreto e identificado.
+                </p>
+            </>
+        ),
+    },
+    {
+        id: 's8',
+        n: '08',
+        title: 'Enlaces a otros sitios web',
+        content: (
+            <>
+                <p>
+                    El Titular puede proporcionarle acceso a sitios web de terceros mediante enlaces con la finalidad
+                    exclusiva de informar sobre la existencia de otras fuentes de información en Internet.
+                </p>
+                <p className="mt-3">
+                    Estos enlaces no suponen en ningún caso una sugerencia o recomendación, y están fuera del control
+                    del Titular, por lo que no se asume responsabilidad del contenido de los sitios web vinculados ni
+                    del resultado que obtenga al seguir los enlaces.
+                </p>
+            </>
+        ),
+    },
+    {
+        id: 's9',
+        n: '09',
+        title: 'Propiedad intelectual e industrial',
+        content: (
+            <p>
+                Todos los derechos están reservados. Todo acceso a este Sitio Web está sujeto a las siguientes
+                condiciones: la reproducción, almacenaje permanente y la difusión de los contenidos o cualquier otro
+                uso que tenga finalidad pública o comercial queda expresamente prohibida sin el consentimiento previo
+                expreso y por escrito del Titular.
+            </p>
+        ),
+    },
+    {
+        id: 's10',
+        n: '10',
+        title: 'Contacto',
+        content: (
+            <>
+                <p>
+                    En caso de que usted tenga cualquier duda acerca de este Aviso Legal o quiera realizar cualquier
+                    comentario sobre el Sitio Web, puede enviar un mensaje de correo electrónico a la dirección:{' '}
+                    <a
+                        href="mailto:impresion221@gmail.com"
+                        className="text-yp-bright border-b border-yp-bright/40 hover:border-yp-bright"
+                    >
+                        impresion221@gmail.com
+                    </a>
+                    .
+                </p>
+                <div className="mt-6 bg-yp-paper border border-yp-line rounded-2xl p-6 flex flex-wrap items-center gap-4 justify-between">
+                    <div>
+                        <div className="text-[10px] tracking-[0.25em] text-yp-muted uppercase mb-1">
+                            ¿Dudas legales?
+                        </div>
+                        <div className="font-display font-bold text-[18px] text-yp-deep">
+                            Escríbenos por email
+                        </div>
+                    </div>
+                    <a
+                        href="mailto:impresion221@gmail.com"
+                        className="inline-flex items-center gap-2 text-[10.5px] tracking-[0.2em] uppercase bg-yp-deep text-accent px-5 py-3 rounded-full hover:bg-yp-mid transition"
+                    >
+                        Contactar →
+                    </a>
+                </div>
+            </>
+        ),
+    },
+];
 
 const LegalAdvicePage: React.FC = () => {
+    const [activeId, setActiveId] = useState<string>(SECTIONS[0].id);
+
+    useEffect(() => {
+        const sections = SECTIONS.map((s) => document.getElementById(s.id)).filter(Boolean) as HTMLElement[];
+        if (!sections.length) return;
+        const obs = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((e) => {
+                    if (e.isIntersecting) setActiveId(e.target.id);
+                });
+            },
+            { rootMargin: '-40% 0px -55% 0px' },
+        );
+        sections.forEach((s) => obs.observe(s));
+        return () => obs.disconnect();
+    }, []);
+
     return (
-        <div className='bg-background-primary font-bahamas-bold'>
-            <div className="bg-white max-w-4xl mx-auto px-4 py-8 font-sans mt-6 mb-6 font-bahamas_bold">
-                <h1 className="text-3xl font-bold text-title-light text-center mb-8">Aviso Legal</h1>
+        <>
+            <Helmet>
+                <title>Aviso Legal | Yanca Publicidad</title>
+                <meta
+                    name="description"
+                    content="Términos y condiciones que regulan el acceso y uso del sitio web de Yanca Publicidad."
+                />
+            </Helmet>
 
-                <section className="mb-8">
-                    <h2 className="text-2xl text-subtitle-light font-semibold mb-4">Identificación y Titularidad</h2>
-                    <p className="text-text-light mb-4">A continuación el Titular expone sus datos identificativos:</p>
-                    <ul className="list-none space-y-2 text-text-light">
-                        <li>Titular: ANDRES PRADO</li>
-                        <li>Cédula de ciudadanía: 1151966382</li>
-                        <li>Domicilio: Cra 4 - 19-37, Valle del Cauca - Colombia</li>
-                        <li>Correo electrónico: impresion221@gmail.com</li>
-                        <li>Sitio Web: https://www.yancapublicidad.com</li>
-                    </ul>
+            <main className="bg-yp-paper" style={{ scrollPaddingTop: '96px' }}>
+                {/* Hero */}
+                <section className="relative yp-gradient-radial text-white overflow-hidden">
+                    <div className="absolute inset-0 grid-bg opacity-50 pointer-events-none" />
+                    <div className="relative max-w-[1200px] mx-auto px-6 py-16 lg:py-20">
+                        <nav className="flex items-center gap-2 text-[11px] tracking-[0.3em] text-accent mb-4 uppercase">
+                            <Link to="/" className="hover:text-white transition">
+                                INICIO
+                            </Link>
+                            <span>·</span>
+                            <span>LEGAL</span>
+                            <span>·</span>
+                            <span className="text-white">AVISO LEGAL</span>
+                        </nav>
+                        <h1 className="font-display font-black text-[44px] sm:text-[64px] lg:text-[76px] leading-[0.95] tracking-tight max-w-[900px]">
+                            Aviso<br />legal.
+                        </h1>
+                        <p className="mt-5 text-white/70 max-w-[620px] text-[15px] leading-relaxed">
+                            Términos y condiciones que regulan el acceso y uso del sitio web de Yanca Publicidad.
+                            Léelos antes de utilizar nuestros servicios.
+                        </p>
+                        <div className="mt-8 flex flex-wrap gap-2 text-[10px] tracking-[0.2em] uppercase">
+                            <span className="px-3 py-1.5 rounded-full bg-white/10 border border-white/15">
+                                Última actualización · Mar 2025
+                            </span>
+                            <span className="px-3 py-1.5 rounded-full bg-white/10 border border-white/15">
+                                Versión · 1.0
+                            </span>
+                            <span className="px-3 py-1.5 rounded-full bg-accent text-yp-deep font-bold">
+                                {SECTIONS.length} secciones
+                            </span>
+                        </div>
+                    </div>
                 </section>
 
-                <section className="mb-8">
-                    <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Finalidad</h2>
-                    <p className="text-text-light">La finalidad del Sitio Web es: general information about solar panels.</p>
-                </section>
+                {/* Content */}
+                <section className="max-w-[1200px] mx-auto px-6 py-14 grid lg:grid-cols-[260px_1fr] gap-10">
+                    {/* TOC */}
+                    <aside className="lg:sticky lg:top-[96px] lg:self-start">
+                        <div className="bg-white rounded-2xl border border-yp-line card-shadow p-5">
+                            <div className="text-[10px] tracking-[0.25em] text-yp-muted uppercase mb-3">Índice</div>
+                            <nav className="flex flex-col gap-1">
+                                {SECTIONS.map((s) => {
+                                    const active = s.id === activeId;
+                                    return (
+                                        <a
+                                            key={s.id}
+                                            href={`#${s.id}`}
+                                            className={`font-display font-semibold text-[13px] px-3 py-2 rounded-lg flex items-baseline gap-2 transition ${
+                                                active
+                                                    ? 'bg-yp-deep text-accent'
+                                                    : 'text-yp-deep hover:bg-yp-paper'
+                                            }`}
+                                        >
+                                            <span
+                                                className={`text-[10px] ${
+                                                    active ? 'text-accent/80' : 'text-yp-muted'
+                                                }`}
+                                            >
+                                                {s.n}
+                                            </span>
+                                            <span>{s.title}</span>
+                                        </a>
+                                    );
+                                })}
+                            </nav>
+                            <div className="mt-5 pt-5 border-t border-yp-line">
+                                <Link
+                                    to="/politicas-privacidad"
+                                    className="flex items-center justify-between text-[10px] tracking-[0.2em] uppercase text-yp-muted hover:text-yp-deep transition"
+                                >
+                                    <span>Política de Privacidad</span>
+                                    <span>→</span>
+                                </Link>
+                            </div>
+                        </div>
+                    </aside>
 
-                <section className="mb-8">
-                    <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Condiciones de Uso</h2>
-                    <p className="text-text-light mb-4">La utilización del Sitio Web le otorga la condición de Usuario, e implica la aceptación completa de todas las cláusulas y condiciones de uso incluidas en las páginas:</p>
-                    <ul className="list-disc pl-6 text-text-text mb-4">
-                        <li>Aviso Legal</li>
-                        <li>Política de Privacidad</li>
-                    </ul>
-                    <p className="text-text-light mb-4">Si no estuviera conforme con todas y cada una de estas cláusulas y condiciones absténgase de utilizar el Sitio Web.</p>
-                    <p className="text-text-light">El acceso al Sitio Web no supone, en modo alguno, el inicio de una relación comercial con el Titular.</p>
-                </section>
+                    {/* Article */}
+                    <article className="space-y-10">
+                        {/* Titular card */}
+                        <div className="bg-yp-deep rounded-2xl p-7 text-white relative overflow-hidden">
+                            <div className="absolute -top-10 -right-10 w-48 h-48 rounded-full bg-accent/15 blur-3xl" />
+                            <div className="relative">
+                                <div className="text-[10px] tracking-[0.3em] text-accent mb-3 uppercase">
+                                    Datos del titular
+                                </div>
+                                <div className="grid sm:grid-cols-2 gap-x-8 gap-y-3 text-[13.5px]">
+                                    <div>
+                                        <div className="text-[10px] uppercase tracking-wider text-white/50 mb-0.5">
+                                            Titular
+                                        </div>
+                                        <div className="font-display font-bold">Andrés Prado</div>
+                                    </div>
+                                    <div>
+                                        <div className="text-[10px] uppercase tracking-wider text-white/50 mb-0.5">
+                                            Cédula
+                                        </div>
+                                        <div>1.151.966.382</div>
+                                    </div>
+                                    <div className="sm:col-span-2">
+                                        <div className="text-[10px] uppercase tracking-wider text-white/50 mb-0.5">
+                                            Domicilio
+                                        </div>
+                                        <div>Cra 4 · 19-37 · Cali · Valle del Cauca · Colombia</div>
+                                    </div>
+                                    <div>
+                                        <div className="text-[10px] uppercase tracking-wider text-white/50 mb-0.5">
+                                            Email
+                                        </div>
+                                        <a
+                                            href="mailto:impresion221@gmail.com"
+                                            className="text-accent hover:underline"
+                                        >
+                                            impresion221@gmail.com
+                                        </a>
+                                    </div>
+                                    <div>
+                                        <div className="text-[10px] uppercase tracking-wider text-white/50 mb-0.5">
+                                            Sitio web
+                                        </div>
+                                        <a
+                                            href="https://www.yancapublicidad.com"
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            className="text-accent hover:underline"
+                                        >
+                                            yancapublicidad.com
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
 
-                <section className="mb-8">
-                    <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Medidas de seguridad</h2>
-                    <p className="text-text-light mb-4">Los datos personales que facilite al Titular pueden ser almacenados en bases de datos automatizadas o no, cuya titularidad corresponde en exclusiva al Titular, que asume todas las medidas de índole técnica, organizativa y de seguridad que garantizan la confidencialidad, integridad y calidad de la información contenida en las mismas de acuerdo con lo establecido en la normativa vigente en protección de datos.</p>
-                    <p className="text-text-light">No obstante, debe ser consciente que las medidas de seguridad de los sistemas informáticos en Internet no son enteramente fiables y que, por tanto el Titular no puede garantizar la inexistencia de virus u otros elementos que puedan producir alteraciones en los sistemas informáticos (software y hardware) del Usuario o en sus documentos electrónicos y ficheros contenidos en los mismos aunque el Titular pone todos los medios necesarios y toma las medidas de seguridad oportunas para evitar la presencia de estos elementos dañinos.</p>
+                        {/* Sections */}
+                        {SECTIONS.map((s) => (
+                            <section key={s.id} id={s.id} className="scroll-mt-24">
+                                <div className="text-[10px] tracking-[0.3em] text-yp-muted uppercase mb-2">
+                                    Sección · {s.n}
+                                </div>
+                                <h3 className="font-display font-extrabold text-[26px] text-yp-deep mb-3">
+                                    {s.title}
+                                </h3>
+                                <div className="text-yp-ink leading-[1.7] text-[15px]">{s.content}</div>
+                            </section>
+                        ))}
+                    </article>
                 </section>
-
-                <section className="mb-8">
-                    <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Tratamiento de Datos Personales</h2>
-                    <p className="text-text-light">Puede consultar toda la información relativa al tratamiento de datos personales que recoge el Titular en la página de Política de Privacidad.</p>
-                </section>
-
-                <section className="mb-8">
-                    <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Contenidos</h2>
-                    <p className="text-text-light mb-4">El Titular ha obtenido la información, el contenido multimedia y los materiales incluidos en el Sitio Web de fuentes que considera fiables, pero, si bien ha tomado todas las medidas razonables para asegurar que la información contenida es correcta, el Titular no garantiza que sea exacta, completa o actualizada. El Titular declina expresamente cualquier responsabilidad por error u omisión en la información contenida en las páginas del Sitio Web.</p>
-                    <p className="text-text-light">Queda prohibido transmitir o enviar a través del Sitio Web cualquier contenido ilegal o ilícito, virus informáticos, o mensajes que, en general, afecten o violen derechos del Titular o de terceros.</p>
-                </section>
-
-                <section className="mb-8">
-                    <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Política de cookies</h2>
-                    <p className="text-text-light mb-4">El Titular obtiene y conserva la siguiente información acerca de los visitantes del Sitio Web:</p>
-                    <ul className="list-disc pl-6 mt-4 space-y-2 text-text-light">
-                        <li>El nombre de dominio del proveedor (PSI) y/o dirección IP que les da acceso a la red.</li>
-                        <li>La fecha y hora de acceso al sitio Web.</li>
-                        <li>La dirección de Internet origen del enlace que dirige al sitio Web.</li>
-                        <li>El número de visitantes diarios de cada sección.</li>
-                    </ul>
-                    <p className="text-text-light">La información obtenida es totalmente anónima, y en ningún caso puede ser asociada a un Usuario concreto e identificado.</p>
-                </section>
-
-                <section className="mb-8">
-                    <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Enlaces a otros sitios Web</h2>
-                    <p className="text-text-light mb-4">El Titular puede proporcionarle acceso a sitios Web de terceros mediante enlaces con la finalidad exclusiva de informar sobre la existencia de otras fuentes de información en Internet en las que podrá ampliar los datos ofrecidos en el Sitio Web.</p>
-                    <p className="text-text-light">Estos enlaces a otros sitios Web no suponen en ningún caso una sugerencia o recomendación para que usted visite las páginas web de destino, que están fuera del control del Titular, por lo que el Titular no es responsable del contenido de los sitios web vinculados ni del resultado que obtenga al seguir los enlaces.</p>
-                </section>
-
-                <section className="mb-8">
-                    <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Propiedad intelectual e industrial</h2>
-                    <p className="text-text-light mb-4">Todos los derechos están reservados.</p>
-                    <p className="text-text-light">Todo acceso a este Sitio Web está sujeto a las siguientes condiciones: la reproducción, almacenaje permanente y la difusión de los contenidos o cualquier otro uso que tenga finalidad pública o comercial queda expresamente prohibida sin el consentimiento previo expreso y por escrito del Titular.</p>
-                </section>
-
-                <section className="mb-8">
-                    <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Limitación de responsabilidad</h2>
-                    <p className="text-text-light mb-4">La información y servicios incluidos o disponibles a través del Sitio Web pueden incluir incorrecciones o errores tipográficos. De forma periódica el Titular incorpora mejoras y/o cambios a la información contenida y/o los Servicios que puede introducir en cualquier momento.</p>
-                    <p className="text-text-light">El Titular no declara ni garantiza que los servicios o contenidos sean interrumpidos o que estén libres de errores, que los defectos sean corregidos, o que el servicio o el servidor que lo pone a disposición estén libres de virus u otros componentes nocivos sin perjuicio de que el Titular realiza todos los esfuerzos en evitar este tipo de incidentes.</p>
-                </section>
-
-                <section className="mb-8">
-                    <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Contacto</h2>
-                    <p className="text-text-light">En caso de que usted tenga cualquier duda acerca de este Aviso Legal o quiera realizar cualquier comentario sobre el Sitio Web, puede enviar un mensaje de correo electrónico a la dirección: impresion221@gmail.com</p>
-                </section>
-            </div>
-        </div>
+            </main>
+        </>
     );
 };
 

--- a/src/pages/legal/PrivacyPolicyPage.tsx
+++ b/src/pages/legal/PrivacyPolicyPage.tsx
@@ -1,82 +1,371 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+import Icon from '../../components/icon/Icon';
 
-const PrivacyPolicyPage: React.FC = () => {
-    return (
-        <div className='bg-background-primary font-bahamas-bold'>
-            <div className="container bg-white mx-auto px-4 py-8 max-w-4xl text-gray-700 mt-6 mb-6">
-                <h1 className="text-3xl font-bold text-title-light mb-6">Política de Privacidad</h1>
-                
-                <div className="space-y-6">
-                    <p className="text-text-light">
-                        El Titular le informa sobre su Política de Privacidad respecto del tratamiento y protección de los datos de carácter personal de los usuarios que puedan ser recabados durante la navegación a través del Sitio Web: <a href="https://www.yancapublicidad.com" className="text-blue-600 hover:underline">https://www.yancapublicidad.com</a>
-                    </p>
+type Section = { id: string; n: string; title: string; content: React.ReactNode };
 
-                    <p className="text-text-light">
-                        En este sentido, el Titular cumple con el Reglamento (UE) 2016/679 del Parlamento Europeo y del Consejo de 27 de abril de 2016 relativo a la protección de las personas físicas (RGPD).
-                    </p>
+const PRINCIPLES = [
+    {
+        n: '01',
+        title: 'Licitud, lealtad y transparencia',
+        body: 'El Titular siempre requerirá el consentimiento para el tratamiento de los datos personales, informando previamente al Usuario con absoluta transparencia.',
+    },
+    {
+        n: '02',
+        title: 'Minimización de datos',
+        body: 'El Titular solicitará solo los datos estrictamente necesarios para el fin o los fines que los solicita.',
+    },
+    {
+        n: '03',
+        title: 'Limitación del plazo',
+        body: 'Los datos personales recabados se mantendrán durante el tiempo estrictamente necesario para el fin o los fines del tratamiento.',
+    },
+    {
+        n: '04',
+        title: 'Integridad y confidencialidad',
+        body: 'Los datos personales recabados serán tratados de tal manera que su seguridad, confidencialidad e integridad están garantizadas.',
+    },
+];
 
-                    <p className="text-text-light">
-                        El uso de sitio Web implica la aceptación de esta Política de Privacidad así como las condiciones incluidas en el Aviso Legal.
-                    </p>
+const RIGHTS: { icon: string; title: string; body: string }[] = [
+    { icon: 'eye', title: 'Acceso', body: 'Solicitar el acceso a los datos almacenados sobre usted.' },
+    { icon: 'check', title: 'Rectificación / supresión', body: 'Solicitar una rectificación o la supresión de sus datos.' },
+    { icon: 'lock', title: 'Limitación', body: 'Solicitar la limitación de su tratamiento en casos específicos.' },
+    { icon: 'close', title: 'Oposición', body: 'Oponerse al tratamiento de sus datos personales.' },
+];
 
-                    <section className="mt-8">
-                        <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Identidad del Responsable</h2>
-                        <ul className="list-none space-y-2 text-text-light">
-                            <li><strong>Responsable:</strong> ANDRES PRADO</li>
-                            <li><strong>Cédula de ciudadanía:</strong> 1151966382</li>
-                            <li><strong>Domicilio:</strong> Cra 4 - 19-37, Valle del Cauca - Colombia</li>
-                            <li><strong>Correo electrónico:</strong> <a href="mailto:impresion221@gmail.com" className="text-blue-600 hover:underline">impresion221@gmail.com</a></li>
-                            <li><strong>Sitio Web:</strong> <a href="https://www.yancapublicidad.com" className="text-blue-600 hover:underline">https://www.yancapublicidad.com</a></li>
-                        </ul>
-                    </section>
-
-                    <section className="mt-8">
-                        <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Principios aplicados en el tratamiento de datos</h2>
-                        <p className="text-text-light">En el tratamiento de sus datos personales, el Titular aplicará los siguientes principios que se ajustan a las exigencias del nuevo reglamento europeo de protección de datos (RGPD):</p>
-                        <ul className="list-disc pl-6 mt-4 space-y-2 text-text-light">
-                            <li><strong>Principio de licitud, lealtad y transparencia:</strong> El Titular siempre requerirá el consentimiento para el tratamiento de los datos personales que puede ser para uno o varios fines específicos sobre los que el Titular informará al Usuario previamente con absoluta transparencia.</li>
-                            <li><strong>Principio de minimización de datos:</strong> El Titular solicitará solo los datos estrictamente necesarios para el fin o los fines que los solicita.</li>
-                            <li><strong>Principio de limitación del plazo de conservación:</strong> El Titular mantendrá los datos personales recabados durante el tiempo estrictamente necesario para el fin o los fines del tratamiento.</li>
-                            <li><strong>Principio de integridad y confidencialidad:</strong> Los datos personales recabados serán tratados de tal manera que su seguridad, confidencialidad e integridad está garantizada.</li>
-                        </ul>
-                    </section>
-
-                    <section className="mt-8">
-                        <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Derechos</h2>
-                        <p className="text-text-light">El Titular le informa que sobre sus datos personales tiene derecho a:</p>
-                        <ul className="list-disc pl-6 mt-4 space-y-2 text-text-light">
-                            <li>Solicitar el acceso a los datos almacenados</li>
-                            <li>Solicitar una rectificación o la supresión</li>
-                            <li>Solicitar la limitación de su tratamiento</li>
-                            <li>Oponerse al tratamiento</li>
-                        </ul>
-                        <p className="mt-4 text-text-light">No puede ejercitar el derecho a la portabilidad de los datos.</p>
-                    </section>
-
-                    <section className="mt-8">
-                        <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Finalidad del tratamiento de datos personales</h2>
-                        <p className="text-text-light">Cuando usted se conecta al Sitio Web para mandar un correo al Titular, se suscribe a su boletín está facilitando información de carácter personal de la que el responsable es el Titular. Esta información puede incluir datos de carácter personal como pueden ser su dirección IP, nombre y apellidos, dirección física, dirección de correo electrónico, número de teléfono, y otra información.</p>
-                    </section>
-
-                    <section className="mt-8">
-                        <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Seguridad de los datos personales</h2>
-                        <p className="text-text-light">Para proteger sus datos personales, el Titular toma todas las precauciones razonables y sigue las mejores prácticas de la industria para evitar su pérdida, mal uso, acceso indebido, divulgación, alteración o destrucción de los mismos.</p>
-                    </section>
-
-                    <section className="mt-8">
-                        <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Política de Cookies</h2>
-                        <p className="text-text-light">Para que este sitio Web funcione correctamente necesita utilizar cookies, que es una información que se almacena en su navegador web.</p>
-                    </section>
-
-                    <section className="mt-8">
-                        <h2 className="text-2xl font-semibold text-subtitle-light mb-4">Cambios en la Política de Privacidad</h2>
-                        <p className="text-text-light">El Titular se reserva el derecho a modificar la presente Política de Privacidad para adaptarla a novedades legislativas o jurisprudenciales, así como a prácticas de la industria.</p>
-                        <p className="mt-2 text-text-light">Estas políticas estarán vigentes hasta que sean modificadas por otras debidamente publicadas.</p>
-                    </section>
-                </div>
+const TITULAR = (
+    <div className="bg-yp-deep rounded-2xl p-6 text-white relative overflow-hidden">
+        <div className="absolute -top-10 -right-10 w-48 h-48 rounded-full bg-accent/15 blur-3xl" />
+        <div className="relative grid sm:grid-cols-2 gap-x-8 gap-y-3 text-[13.5px]">
+            <div>
+                <div className="text-[10px] uppercase tracking-wider text-white/50 mb-0.5">Responsable</div>
+                <div className="font-display font-bold">Andrés Prado</div>
+            </div>
+            <div>
+                <div className="text-[10px] uppercase tracking-wider text-white/50 mb-0.5">Cédula</div>
+                <div>1.151.966.382</div>
+            </div>
+            <div className="sm:col-span-2">
+                <div className="text-[10px] uppercase tracking-wider text-white/50 mb-0.5">Domicilio</div>
+                <div>Cra 4 · 19-37 · Cali · Valle del Cauca · Colombia</div>
+            </div>
+            <div>
+                <div className="text-[10px] uppercase tracking-wider text-white/50 mb-0.5">Email</div>
+                <a href="mailto:impresion221@gmail.com" className="text-accent hover:underline">
+                    impresion221@gmail.com
+                </a>
+            </div>
+            <div>
+                <div className="text-[10px] uppercase tracking-wider text-white/50 mb-0.5">Sitio web</div>
+                <a
+                    href="https://www.yancapublicidad.com"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-accent hover:underline"
+                >
+                    yancapublicidad.com
+                </a>
             </div>
         </div>
-    )
-}
+    </div>
+);
+
+const SECTIONS: Section[] = [
+    { id: 's1', n: '01', title: 'Identidad del responsable', content: TITULAR },
+    {
+        id: 's2',
+        n: '02',
+        title: 'Principios aplicados en el tratamiento',
+        content: (
+            <>
+                <p>
+                    En el tratamiento de sus datos personales, el Titular aplicará los siguientes principios que se
+                    ajustan a las exigencias del nuevo reglamento europeo de protección de datos (RGPD):
+                </p>
+                <div className="mt-5 grid sm:grid-cols-2 gap-3">
+                    {PRINCIPLES.map((p) => (
+                        <div key={p.n} className="bg-white border border-yp-line rounded-xl p-5">
+                            <div className="text-[10px] tracking-[0.25em] text-accent mb-2">{p.n}</div>
+                            <div className="font-display font-bold text-[15px] text-yp-deep mb-1.5">{p.title}</div>
+                            <p className="text-[13px]">{p.body}</p>
+                        </div>
+                    ))}
+                </div>
+            </>
+        ),
+    },
+    {
+        id: 's3',
+        n: '03',
+        title: 'Tus derechos',
+        content: (
+            <>
+                <p>El Titular le informa que sobre sus datos personales tiene derecho a:</p>
+                <div className="mt-5 space-y-2">
+                    {RIGHTS.map((r) => (
+                        <div key={r.title} className="flex items-start gap-4 bg-white border border-yp-line rounded-xl p-4">
+                            <div className="size-9 rounded-lg bg-yp-paper grid place-items-center text-yp-deep shrink-0">
+                                <Icon name={r.icon} className="h-4 w-4" />
+                            </div>
+                            <div>
+                                <div className="font-display font-bold text-[14px] text-yp-deep">{r.title}</div>
+                                <div className="text-[13px]">{r.body}</div>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+                <div className="mt-5 bg-accent/10 border border-accent/40 rounded-xl p-4 text-[13px]">
+                    <span className="font-display font-bold text-yp-deep">Nota · </span>
+                    No puede ejercitar el derecho a la portabilidad de los datos.
+                </div>
+            </>
+        ),
+    },
+    {
+        id: 's4',
+        n: '04',
+        title: 'Finalidad del tratamiento',
+        content: (
+            <p>
+                Cuando usted se conecta al Sitio Web para mandar un correo al Titular, o se suscribe a su boletín, está
+                facilitando información de carácter personal de la que el responsable es el Titular. Esta información
+                puede incluir datos de carácter personal como: dirección IP, nombre y apellidos, dirección física,
+                dirección de correo electrónico, número de teléfono, y otra información.
+            </p>
+        ),
+    },
+    {
+        id: 's5',
+        n: '05',
+        title: 'Seguridad de los datos personales',
+        content: (
+            <p>
+                Para proteger sus datos personales, el Titular toma todas las precauciones razonables y sigue las
+                mejores prácticas de la industria para evitar su pérdida, mal uso, acceso indebido, divulgación,
+                alteración o destrucción de los mismos.
+            </p>
+        ),
+    },
+    {
+        id: 's6',
+        n: '06',
+        title: 'Política de cookies',
+        content: (
+            <p>
+                Para que este sitio Web funcione correctamente necesita utilizar cookies, que es información que se
+                almacena en su navegador web.
+            </p>
+        ),
+    },
+    {
+        id: 's7',
+        n: '07',
+        title: 'Cambios en la política',
+        content: (
+            <>
+                <p>
+                    El Titular se reserva el derecho a modificar la presente Política de Privacidad para adaptarla a
+                    novedades legislativas o jurisprudenciales, así como a prácticas de la industria.
+                </p>
+                <p className="mt-3">
+                    Estas políticas estarán vigentes hasta que sean modificadas por otras debidamente publicadas.
+                </p>
+            </>
+        ),
+    },
+    {
+        id: 's8',
+        n: '08',
+        title: 'Contacto',
+        content: (
+            <>
+                <p>
+                    Para ejercer sus derechos o resolver dudas sobre el tratamiento de sus datos, puede contactarnos
+                    escribiendo a{' '}
+                    <a
+                        href="mailto:impresion221@gmail.com"
+                        className="text-yp-bright border-b border-yp-bright/40 hover:border-yp-bright"
+                    >
+                        impresion221@gmail.com
+                    </a>
+                    .
+                </p>
+                <div className="mt-6 bg-yp-paper border border-yp-line rounded-2xl p-6 flex flex-wrap items-center gap-4 justify-between">
+                    <div>
+                        <div className="text-[10px] tracking-[0.25em] text-yp-muted uppercase mb-1">
+                            Ejercer mis derechos
+                        </div>
+                        <div className="font-display font-bold text-[18px] text-yp-deep">Escríbenos por email</div>
+                    </div>
+                    <a
+                        href="mailto:impresion221@gmail.com"
+                        className="inline-flex items-center gap-2 text-[10.5px] tracking-[0.2em] uppercase bg-yp-deep text-accent px-5 py-3 rounded-full hover:bg-yp-mid transition"
+                    >
+                        Contactar →
+                    </a>
+                </div>
+            </>
+        ),
+    },
+];
+
+const PrivacyPolicyPage: React.FC = () => {
+    const [activeId, setActiveId] = useState<string>(SECTIONS[0].id);
+
+    useEffect(() => {
+        const sections = SECTIONS.map((s) => document.getElementById(s.id)).filter(Boolean) as HTMLElement[];
+        if (!sections.length) return;
+        const obs = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((e) => {
+                    if (e.isIntersecting) setActiveId(e.target.id);
+                });
+            },
+            { rootMargin: '-40% 0px -55% 0px' },
+        );
+        sections.forEach((s) => obs.observe(s));
+        return () => obs.disconnect();
+    }, []);
+
+    return (
+        <>
+            <Helmet>
+                <title>Política de Privacidad | Yanca Publicidad</title>
+                <meta
+                    name="description"
+                    content="Cómo recopilamos, tratamos y protegemos tus datos personales en Yanca Publicidad."
+                />
+            </Helmet>
+
+            <main className="bg-yp-paper">
+                {/* Hero */}
+                <section className="relative yp-gradient-radial text-white overflow-hidden">
+                    <div className="absolute inset-0 grid-bg opacity-50 pointer-events-none" />
+                    <div className="relative max-w-[1200px] mx-auto px-6 py-16 lg:py-20">
+                        <nav className="flex items-center gap-2 text-[11px] tracking-[0.3em] text-accent mb-4 uppercase">
+                            <Link to="/" className="hover:text-white transition">
+                                INICIO
+                            </Link>
+                            <span>·</span>
+                            <span>LEGAL</span>
+                            <span>·</span>
+                            <span className="text-white">POLÍTICA DE PRIVACIDAD</span>
+                        </nav>
+                        <h1 className="font-display font-black text-[44px] sm:text-[64px] lg:text-[76px] leading-[0.95] tracking-tight max-w-[900px]">
+                            Política de<br />privacidad.
+                        </h1>
+                        <p className="mt-5 text-white/70 max-w-[640px] text-[15px] leading-relaxed">
+                            Cómo recopilamos, tratamos y protegemos tus datos personales cuando navegas y solicitas
+                            servicios en Yanca Publicidad.
+                        </p>
+                        <div className="mt-8 flex flex-wrap gap-2 text-[10px] tracking-[0.2em] uppercase">
+                            <span className="px-3 py-1.5 rounded-full bg-white/10 border border-white/15">
+                                Última actualización · Mar 2025
+                            </span>
+                            <span className="px-3 py-1.5 rounded-full bg-white/10 border border-white/15">
+                                RGPD · UE 2016/679
+                            </span>
+                            <span className="px-3 py-1.5 rounded-full bg-accent text-yp-deep font-bold">
+                                {SECTIONS.length} secciones
+                            </span>
+                        </div>
+                    </div>
+                </section>
+
+                {/* Content */}
+                <section className="max-w-[1200px] mx-auto px-6 py-14 grid lg:grid-cols-[260px_1fr] gap-10">
+                    {/* TOC */}
+                    <aside className="lg:sticky lg:top-[96px] lg:self-start">
+                        <div className="bg-white rounded-2xl border border-yp-line card-shadow p-5">
+                            <div className="text-[10px] tracking-[0.25em] text-yp-muted uppercase mb-3">Índice</div>
+                            <nav className="flex flex-col gap-1">
+                                {SECTIONS.map((s) => {
+                                    const active = s.id === activeId;
+                                    return (
+                                        <a
+                                            key={s.id}
+                                            href={`#${s.id}`}
+                                            className={`font-display font-semibold text-[13px] px-3 py-2 rounded-lg flex items-baseline gap-2 transition ${
+                                                active ? 'bg-yp-deep text-accent' : 'text-yp-deep hover:bg-yp-paper'
+                                            }`}
+                                        >
+                                            <span
+                                                className={`text-[10px] ${
+                                                    active ? 'text-accent/80' : 'text-yp-muted'
+                                                }`}
+                                            >
+                                                {s.n}
+                                            </span>
+                                            <span>{s.title}</span>
+                                        </a>
+                                    );
+                                })}
+                            </nav>
+                            <div className="mt-5 pt-5 border-t border-yp-line">
+                                <Link
+                                    to="/aviso-legal"
+                                    className="flex items-center justify-between text-[10px] tracking-[0.2em] uppercase text-yp-muted hover:text-yp-deep transition"
+                                >
+                                    <span>Aviso Legal</span>
+                                    <span>→</span>
+                                </Link>
+                            </div>
+                        </div>
+                    </aside>
+
+                    {/* Article */}
+                    <article className="space-y-10">
+                        {/* Intro */}
+                        <div className="bg-white border border-yp-line rounded-2xl p-7 card-shadow">
+                            <div className="text-[10px] tracking-[0.3em] text-yp-muted uppercase mb-3">Resumen</div>
+                            <p className="text-[15px] text-yp-ink leading-[1.7]">
+                                El Titular le informa sobre su Política de Privacidad respecto del tratamiento y
+                                protección de los datos de carácter personal de los usuarios que puedan ser recabados
+                                durante la navegación a través del Sitio Web{' '}
+                                <a
+                                    href="https://www.yancapublicidad.com"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="text-yp-bright border-b border-yp-bright/40 hover:border-yp-bright"
+                                >
+                                    yancapublicidad.com
+                                </a>
+                                .
+                            </p>
+                            <p className="text-[15px] text-yp-ink leading-[1.7] mt-3">
+                                El Titular cumple con el Reglamento (UE) 2016/679 del Parlamento Europeo y del Consejo
+                                de 27 de abril de 2016 relativo a la protección de las personas físicas (RGPD). El uso
+                                del Sitio Web implica la aceptación de esta Política de Privacidad así como las
+                                condiciones incluidas en el{' '}
+                                <Link
+                                    to="/aviso-legal"
+                                    className="text-yp-bright border-b border-yp-bright/40 hover:border-yp-bright"
+                                >
+                                    Aviso Legal
+                                </Link>
+                                .
+                            </p>
+                        </div>
+
+                        {/* Sections */}
+                        {SECTIONS.map((s) => (
+                            <section key={s.id} id={s.id} className="scroll-mt-24">
+                                <div className="text-[10px] tracking-[0.3em] text-yp-muted uppercase mb-2">
+                                    Sección · {s.n}
+                                </div>
+                                <h3 className="font-display font-extrabold text-[26px] text-yp-deep mb-3">
+                                    {s.title}
+                                </h3>
+                                <div className="text-yp-ink leading-[1.7] text-[15px]">{s.content}</div>
+                            </section>
+                        ))}
+                    </article>
+                </section>
+            </main>
+        </>
+    );
+};
 
 export default PrivacyPolicyPage;

--- a/src/services/serviceCarousel.ts
+++ b/src/services/serviceCarousel.ts
@@ -1,0 +1,12 @@
+import apiClient from '../api/axios';
+import { API_ENDPOINTS } from '../api/endpoints';
+import { GetCarouselImages } from '../types/GetCarouselImages';
+
+const fetchCarouselImages = async (): Promise<GetCarouselImages> => {
+    const response = await apiClient.get(API_ENDPOINTS.carousel.getCarouselImages);
+    return response.data;
+};
+
+export const serviceCarousel = {
+    fetchCarouselImages,
+};

--- a/src/types/GetCarouselImages.ts
+++ b/src/types/GetCarouselImages.ts
@@ -1,0 +1,3 @@
+export interface GetCarouselImages {
+    carouselImages: string[];
+}


### PR DESCRIPTION
## Summary

Three follow-up commits on top of the redesign already merged via #58:

- **Aviso Legal** (`/aviso-legal`) — radial hero, sticky TOC with 10 numbered sections + IntersectionObserver active state, dark titular card, numbered section bodies, final contact CTA. Also fixes a stray "solar panels" placeholder that was in the previous text.
- **Política de Privacidad** (`/politicas-privacidad`) — same layout, 8 sections including a 2×2 RGPD principles card grid and the four-rights list with icons.
- **Hero banner** — re-wired to `GET /carousel/images` after the Phase 6 cleanup removed the hook. `useCarouselImages` returns `{ carouselImages: string[] }`; the rotating slide now uses `images[i % length]` and falls back to the gray placeholder while loading.

## Test plan
- [ ] `/aviso-legal` renders new layout, TOC active state tracks scroll
- [ ] `/politicas-privacidad` renders, TOC works, principles grid + rights list visible
- [ ] Home Hero shows real photos from `/carousel/images`; if the endpoint is unreachable the placeholder is still shown without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)