### PR TITLE
Hero: drop paper background so transparent images blend with gradient

### DIFF
--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -116,7 +116,7 @@ const Hero: React.FC = () => {
                 </div>
 
                 <div className="lg:col-span-5 relative">
-                    <div className="relative aspect-[5/6] rounded-3xl overflow-hidden ring-1 ring-white/10 bg-yp-paper">
+                    <div className="relative aspect-[5/6] rounded-3xl overflow-hidden ring-1 ring-white/10">
                         {imageUrl ? (
                             <img
                                 key={imageUrl}
@@ -126,7 +126,7 @@ const Hero: React.FC = () => {
                                 loading="eager"
                             />
                         ) : (
-                            <div className="absolute inset-0 grid place-items-center font-mono text-[11px] tracking-[0.3em] text-yp-deep/55">
+                            <div className="absolute inset-0 grid place-items-center bg-yp-paper font-mono text-[11px] tracking-[0.3em] text-yp-deep/55">
                                 {s.placeholder}
                             </div>
                         )}


### PR DESCRIPTION
## Summary

Single fix: the Hero image card was painted `bg-yp-paper` (cream), so transparent WebP images showed a beige fill behind their alpha pixels instead of the radial gradient. The cream fill is now scoped to the placeholder state only (no carousel response yet).

## Test plan
- [ ] Home Hero with a transparent WebP carousel image renders against the radial gradient (no cream strip)
- [ ] Placeholder state (block `/carousel/images` in DevTools) still shows the cream card with the mono tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)