### PR TITLE
Hero: rename slide 03 title to Gafetes identificadores

### DIFF
--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -21,7 +21,7 @@ const SLIDES: Slide[] = [
     },
     {
         tag: 'IMPRESIÓN UV SOBRE RÍGIDOS',
-        title: 'Tu idea sobre cualquier superficie.',
+        title: 'Gafetes identificadores.',
         sub: 'Vidrio, metal, madera, acrílico — impresión directa con tinta UV-LED.',
         placeholder: 'UV · CABEZOTE',
     },

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -21,7 +21,7 @@ const SLIDES: Slide[] = [
     },
     {
         tag: 'IMPRESIÓN UV SOBRE RÍGIDOS',
-        title: 'Gafetes identificadores.',
+        title: 'Gafetes identificadores',
         sub: 'Vidrio, metal, madera, acrílico — impresión directa con tinta UV-LED.',
         placeholder: 'UV · CABEZOTE',
     },


### PR DESCRIPTION
## Summary

Two-line content tweak on Hero slide 03:

- Replaces "Tu idea sobre cualquier superficie." with "Gafetes identificadores" as the slide title.
- Drops the trailing period from the data — the slide renderer already appends a "." to the first line for multi-clause titles, so leaving it in produced a double period.

## Test plan
- [ ] Home Hero rotates and slide 03 shows "Gafetes identificadores." (single period)

🤖 Generated with [Claude Code](https://claude.com/claude-code)