### PR TITLE
Hero: rewrite slide 01/02 copy and align tags

### DIFF
--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -9,8 +9,8 @@ type Slide = { tag: string; title: string; sub: string; placeholder: string };
 const SLIDES: Slide[] = [
     {
         tag: 'IMPRESIÓN DTF UV',
-        title: 'Color que se queda. Detalle que se ve.',
-        sub: 'Producción profesional con acabados premium para marcas, talleres y agencias.',
+        title: 'Corte y Grabado Láser',
+        sub: 'Ofrecemos servicio de corte láser y grabado sobre diferentes sustratos como metal, madera, cuero, plástico y vidrio. Contamos con equipos Trotec, IPG y Epilog y una robusta experiencia que te garantizará la máxima calidad del mercado.',
         placeholder: 'DTF · CABEZOTE',
     },
     {

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -15,8 +15,8 @@ const SLIDES: Slide[] = [
     },
     {
         tag: 'CORTE Y GRABADO LÁSER',
-        title: 'Cortes precisos. Grabados que enamoran.',
-        sub: 'Trabajamos acrílico, MDF, madera, cuero y más con tolerancia milimétrica.',
+        title: 'Impresión full color sobre rígidos',
+        sub: 'Contamos con tecnología UV-LED, que te permite marcar sustratos a full color como vidrio, plástico, madera y otros materiales tanto flexibles como rígidos.',
         placeholder: 'LÁSER · CABEZOTE',
     },
     {

--- a/src/components/homepage/Hero.tsx
+++ b/src/components/homepage/Hero.tsx
@@ -8,19 +8,19 @@ type Slide = { tag: string; title: string; sub: string; placeholder: string };
 
 const SLIDES: Slide[] = [
     {
-        tag: 'IMPRESIÓN DTF UV',
+        tag: 'CORTE Y GRABADO LÁSER',
         title: 'Corte y Grabado Láser',
         sub: 'Ofrecemos servicio de corte láser y grabado sobre diferentes sustratos como metal, madera, cuero, plástico y vidrio. Contamos con equipos Trotec, IPG y Epilog y una robusta experiencia que te garantizará la máxima calidad del mercado.',
         placeholder: 'DTF · CABEZOTE',
     },
     {
-        tag: 'CORTE Y GRABADO LÁSER',
+        tag: 'IMPRESIÓN FULL COLOR SOBRE RÍGIDOS',
         title: 'Impresión full color sobre rígidos',
         sub: 'Contamos con tecnología UV-LED, que te permite marcar sustratos a full color como vidrio, plástico, madera y otros materiales tanto flexibles como rígidos.',
         placeholder: 'LÁSER · CABEZOTE',
     },
     {
-        tag: 'IMPRESIÓN UV SOBRE RÍGIDOS',
+        tag: 'GAFETES IDENTIFICADORES',
         title: 'Gafetes identificadores',
         sub: 'Vidrio, metal, madera, acrílico — impresión directa con tinta UV-LED.',
         placeholder: 'UV · CABEZOTE',


### PR DESCRIPTION
## Summary

Hero slide content update — replaces the placeholder marketing copy with the customer's real service descriptions and aligns each slide's eyebrow tag to its title.

| # | Tag                                | Title                                  |
|---|------------------------------------|----------------------------------------|
| 01| CORTE Y GRABADO LÁSER              | Corte y Grabado Láser                  |
| 02| IMPRESIÓN FULL COLOR SOBRE RÍGIDOS | Impresión full color sobre rígidos     |
| 03| GAFETES IDENTIFICADORES            | Gafetes identificadores                |

Subtitles updated for 01 (laser cutting/engraving substrates + Trotec/IPG/Epilog equipment claim) and 02 (UV-LED full color print on flexible and rigid substrates).

## Test plan
- [ ] Home Hero rotates between the three slides; tag and title agree on every slide
- [ ] Slide 01 shows the laser cutting/engraving subtitle
- [ ] Slide 02 shows the UV-LED full color subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)