### PR TITLE
fix(home): simplify section headers and reduce vertical spacing

### DIFF
--- a/src/components/homepage/Process.tsx
+++ b/src/components/homepage/Process.tsx
@@ -8,25 +8,10 @@ const STEPS: Step[] = [
 ];
 
 const Process: React.FC = () => (
-    <section className="relative bg-yp-deep text-white py-20 lg:py-28 overflow-hidden">
+    <section className="relative bg-yp-deep text-white pt-20 lg:pt-28 pb-5 lg:pb-7 overflow-hidden">
         <div className="absolute inset-0 grid-bg opacity-50" />
         <div className="absolute -left-40 top-1/2 -translate-y-1/2 w-[420px] h-[420px] rounded-full bg-yp-bright blur-3xl opacity-30" />
         <div className="max-w-[1400px] mx-auto px-6 relative">
-            <div className="grid lg:grid-cols-12 gap-10 items-end mb-14">
-                <div className="lg:col-span-7">
-                    <div className="flex items-center gap-3 text-[11px] font-mono tracking-[0.25em] text-accent">
-                        <span className="size-1.5 rounded-full bg-accent" /> CÓMO TRABAJAMOS
-                    </div>
-                    <h2 className="font-display font-black text-[40px] lg:text-[56px] leading-[1.02] mt-3 tracking-tight">
-                        De la idea al producto en <span className="text-accent">4 pasos</span>.
-                    </h2>
-                </div>
-                <div className="lg:col-span-5 text-white/70 text-[15px] leading-relaxed">
-                    Un proceso simple, transparente y sin sorpresas. Acompañamos cada etapa para que tu pedido llegue
-                    exactamente como lo imaginaste.
-                </div>
-            </div>
-
             <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-px bg-white/10 rounded-2xl overflow-hidden">
                 {STEPS.map((s) => (
                     <div key={s.n} className="bg-yp-deep hover:bg-yp-mid/40 transition p-7 lg:p-9 group relative">
@@ -39,6 +24,12 @@ const Process: React.FC = () => (
                         <div className="mt-7 h-px bg-gradient-to-r from-accent via-white/20 to-transparent w-0 group-hover:w-full transition-all duration-700" />
                     </div>
                 ))}
+            </div>
+
+            <div className="mt-6 flex justify-center">
+                <div className="flex items-center gap-3 text-[11px] font-mono tracking-[0.25em] text-accent">
+                    <span className="size-1.5 rounded-full bg-accent" /> CÓMO TRABAJAMOS
+                </div>
             </div>
         </div>
     </section>

--- a/src/components/homepage/Services.tsx
+++ b/src/components/homepage/Services.tsx
@@ -45,23 +45,8 @@ const SERVICES: Service[] = [
 ];
 
 const Services: React.FC = () => (
-    <section id="servicios" className="relative py-20 lg:py-28 bg-white">
+    <section id="servicios" className="relative pt-20 lg:pt-28 pb-5 lg:pb-7 bg-white">
         <div className="max-w-[1400px] mx-auto px-6 relative">
-            <div className="flex items-end justify-between gap-6 mb-12 flex-wrap">
-                <div className="max-w-[640px]">
-                    <div className="flex items-center gap-3 text-[11px] font-mono tracking-[0.25em] text-yp-bright">
-                        <span className="size-1.5 rounded-full bg-yp-bright" /> NUESTROS SERVICIOS
-                    </div>
-                    <h2 className="font-display font-black text-[40px] lg:text-[56px] leading-[1.02] mt-3 text-yp-deep tracking-tight">
-                        Cuatro técnicas. <span className="text-yp-bright">Una calidad.</span>
-                    </h2>
-                    <p className="mt-4 text-[15px] text-yp-muted leading-relaxed">
-                        Producción profesional con tecnología de punta. Te asesoramos en la mejor técnica según tu material,
-                        volumen y presupuesto.
-                    </p>
-                </div>
-            </div>
-
             <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-5">
                 {SERVICES.map((s) => (
                     <div
@@ -101,6 +86,12 @@ const Services: React.FC = () => (
                         </div>
                     </div>
                 ))}
+            </div>
+
+            <div className="mt-6 flex justify-center">
+                <div className="flex items-center gap-3 text-[11px] font-mono tracking-[0.25em] text-yp-bright">
+                    <span className="size-1.5 rounded-full bg-yp-bright" /> NUESTROS SERVICIOS
+                </div>
             </div>
         </div>
     </section>

--- a/src/components/products/FeaturedProductsCarousel.tsx
+++ b/src/components/products/FeaturedProductsCarousel.tsx
@@ -10,20 +10,8 @@ const FeaturedProductsCarousel: React.FC = () => {
   const { data, isLoading, error } = useGetFeaturedProducts();
 
   return (
-    <section id="productos" className="py-20 lg:py-28 bg-yp-paper border-y border-yp-line">
+    <section id="productos" className="pt-20 lg:pt-28 pb-5 lg:pb-7 bg-yp-paper border-y border-yp-line">
       <div className="max-w-[1400px] mx-auto px-6">
-        <div className="mb-10 max-w-[640px]">
-          <div className="flex items-center gap-3 text-[11px] font-mono tracking-[0.25em] text-yp-bright">
-            <span className="size-1.5 rounded-full bg-yp-bright" /> PRODUCTOS DESTACADOS
-          </div>
-          <h2 className="font-display font-black text-[40px] lg:text-[56px] leading-[1.02] mt-3 text-yp-deep tracking-tight">
-            Listos para producir hoy.
-          </h2>
-          <p className="mt-3 text-[15px] text-yp-muted max-w-[520px]">
-            Los favoritos de nuestros clientes. Personalizables al 100% con tu logo, colores y arte.
-          </p>
-        </div>
-
         {isLoading && <div className="text-yp-muted">Cargando productos...</div>}
         {error && <div className="text-red-500">Error al cargar los productos</div>}
         {!isLoading && !error && !data?.products?.length && (
@@ -66,6 +54,12 @@ const FeaturedProductsCarousel: React.FC = () => {
             </Swiper>
           </>
         )}
+
+        <div className="mt-6 flex justify-center">
+          <div className="flex items-center gap-3 text-[11px] font-mono tracking-[0.25em] text-yp-bright">
+            <span className="size-1.5 rounded-full bg-yp-bright" /> PRODUCTOS DESTACADOS
+          </div>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Se eliminan los títulos grandes (`<h2>`) y subtítulos descriptivos de las secciones Servicios, Cómo Trabajamos y Productos Destacados.
- La etiqueta corta (eyebrow) se mueve al final de cada sección, centrada.
- Se reduce el padding inferior de las tres secciones a `pb-5 lg:pb-7` para evitar espacios en blanco excesivos.

## Test plan
- [ ] Home: verificar que cada sección termina con su eyebrow centrado ("NUESTROS SERVICIOS", "CÓMO TRABAJAMOS", "PRODUCTOS DESTACADOS") y sin párrafos largos.
- [ ] Verificar que el espacio inferior se redujo en desktop y mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)