### PR TITLE
fix(home,inventory): reorder home sections and relocate inventory breadcrumbs

### DIFF
--- a/src/components/products/FeaturedProductsCarousel.tsx
+++ b/src/components/products/FeaturedProductsCarousel.tsx
@@ -10,7 +10,7 @@ const FeaturedProductsCarousel: React.FC = () => {
   const { data, isLoading, error } = useGetFeaturedProducts();
 
   return (
-    <section id="productos" className="pt-10 lg:pt-14 pb-5 lg:pb-7 bg-yp-paper border-y border-yp-line">
+    <section id="productos" className="pt-6 lg:pt-8 pb-5 lg:pb-7 bg-yp-paper border-y border-yp-line">
       <div className="max-w-[1400px] mx-auto px-6">
         {isLoading && <div className="text-yp-muted">Cargando productos...</div>}
         {error && <div className="text-red-500">Error al cargar los productos</div>}


### PR DESCRIPTION
## Summary
- Tighten top padding on Featured Products, Services and Process sections on home
- Swap Services and Process order so the dark/light backgrounds interleave; swap their eyebrow colors (Services → yellow, Process → blue) and set Process step titles to white for contrast
- Remove the "INVENTARIO" tag from the Inventory hero and move breadcrumbs into a light strip below the hero on both the Inventory and Inventories pages

## Test plan
- [ ] Home: section order is Featured Products → Services → Process with alternating light/dark backgrounds
- [ ] Home: eyebrow colors (Services yellow, Process blue); Process step titles readable in white
- [ ] Inventory page: hero no longer shows the "INVENTARIO" tag; breadcrumbs render below the hero
- [ ] Inventories page: breadcrumbs render below the hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)