### PR TITLE
fix(deploy): add Vercel SPA rewrite to fix 404 on reload

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` with a catch-all rewrite to `/index.html` so client-side routes (e.g. `/inventarios`, `/producto/:id`) don't 404 when the user reloads the page on Vercel.

## Test plan
- [ ] After deploy, navigate to `/inventarios` and reload — should render the page instead of a 404
- [ ] Same check on a product detail route like `/producto/:id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)