### PR TITLE
fix(breadcrumbs): use header brand font and force uppercase

### DIFF
--- a/src/pages/project/Inventories.tsx
+++ b/src/pages/project/Inventories.tsx
@@ -24,7 +24,7 @@ const Inventories: React.FC = () => {
 
             {/* Breadcrumbs */}
             <div className="bg-yp-paper border-b border-yp-line">
-                <nav className="max-w-[1400px] mx-auto px-6 py-4 flex items-center gap-2 text-[11px] font-mono tracking-[0.2em] text-yp-muted">
+                <nav className="max-w-[1400px] mx-auto px-6 py-4 flex items-center gap-2 text-[12px] font-bahamas-bold tracking-[0.08em] uppercase text-yp-muted">
                     <Link to="/" className="hover:text-yp-deep transition">INICIO</Link>
                     <span>›</span>
                     <span className="text-yp-deep">CATÁLOGO</span>

--- a/src/pages/project/Inventory.tsx
+++ b/src/pages/project/Inventory.tsx
@@ -99,7 +99,7 @@ const Inventory: React.FC = () => {
 
             {/* Breadcrumbs */}
             <div className="bg-yp-paper border-b border-yp-line">
-                <nav className="max-w-[1400px] mx-auto px-6 py-4 flex items-center gap-2 text-[11px] font-mono tracking-[0.2em] text-yp-muted">
+                <nav className="max-w-[1400px] mx-auto px-6 py-4 flex items-center gap-2 text-[12px] font-bahamas-bold tracking-[0.08em] uppercase text-yp-muted">
                     <Link to="/" className="hover:text-yp-deep transition">INICIO</Link>
                     <span>›</span>
                     <Link to="/inventarios" className="hover:text-yp-deep transition">CATÁLOGO</Link>


### PR DESCRIPTION
## Summary
- Use the header brand font (`font-bahamas-bold`) for breadcrumbs on the Inventory and Inventories pages
- Force `uppercase` on the breadcrumb nav so dynamic crumbs (e.g. the inventory title) render in caps consistently

## Test plan
- [ ] Inventory and Inventories pages render breadcrumbs in the same typeface as "YANCA PUBLICIDAD" in the header
- [ ] All crumb segments display in uppercase regardless of source casing

🤖 Generated with [Claude Code](https://claude.com/claude-code)